### PR TITLE
V8 crashed when regexp in line 196 reaches new lines or carriage returns

### DIFF
--- a/php-unserialize.js
+++ b/php-unserialize.js
@@ -193,7 +193,8 @@ function unserializeSession (input) {
     }
     // Other output = $someSerializedStuff$key
     else {
-      var match = part.match(/^((?:.*?[;\}])+)([^;\}]+?)$/);
+      var repper = part.replace(/(\n|\r)/g," ");
+	var match = repper.match(/^((?:.*?[;\}])+)([^;\}]+?)$/);
       if (match) {
         output[output._currKey] = unserialize(match[1]);
         output._currKey = match[2];


### PR DESCRIPTION
If a serialized php session contains strings with new line or carriage return chars, the `var match = part.match(/^((?:.*?[;\}])+)([^;\}]+?)$/)` call to `match`will never return. V8 will hang.

I added a line replacing these chars with spaces, to keep the correct length of the data segments as defined in the PHP serialized format.

If you need a serialized string to verify this issue please just contact me.