### PR TITLE
Added support for browserify

### DIFF
--- a/php-unserialize.js
+++ b/php-unserialize.js
@@ -206,4 +206,4 @@ function unserializeSession (input) {
 }
 
 // /Wrapper
-})((typeof window === 'undefined') ? global : window, (typeof window === 'undefined') ? exports : (window.PHPUnserialize = {}));
+})((typeof window === 'undefined') ? global : window, (typeof exports === 'undefined') ? (window.PHPUnserialize = {}) : exports);


### PR DESCRIPTION
If the exports object is defined then it is used instead of the global window object